### PR TITLE
Add PCBWay sponsored segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ Hardware designs are availible at https://github.com/RATsynthesizers/FXcursion-H
 
 Documentation currently lives in the
 [wiki](https://github.com/Predtech4/ProtoStack_H743VI_V0.2/wiki).
+
+
+## Sponsors
+
+[PCBWay][pcbway] sponsored our project with free PCB prototyping services.
+You can read more about our experience working with them [on our Hackaday][pcbway-post].
+
+[pcbway]: https://pcbway.com/g/i4SuPL
+[pcbway-post]: https://hackaday.io/project/192448-fxcursion/log/225631-we-have-been-sponsored-by-pcbway


### PR DESCRIPTION
Liam from PCBWay asked if we can add a sponsored segment to our GitHub as well. I propose we keep it brief and link to the post for those interested in details.

I've also used my referral link for now (but I'd be happy to swap it with somebody else’s if you’d like that :-). I've checked with Liam and PCBWay is comfortable with that. And if we get enough commissions, we might use those to further fund our project, so I perhaps we can use one in the post as well?